### PR TITLE
Update license identifier & unlock base & library contract pragmas

### DIFF
--- a/solidity/src/CadenceArchUtils.sol
+++ b/solidity/src/CadenceArchUtils.sol
@@ -1,5 +1,5 @@
-// SPDX-License-Identifier: MIT
-pragma solidity 0.8.19;
+// SPDX-License-Identifier: Unlicense
+pragma solidity ^0.8.19;
 
 /**
  * @dev This contract is a base contract to facilitate easier consumption of the Cadence Arch pre-compiles. Implementing

--- a/solidity/src/CadenceRandomConsumer.sol
+++ b/solidity/src/CadenceRandomConsumer.sol
@@ -1,5 +1,5 @@
-// SPDX-License-Identifier: MIT
-pragma solidity 0.8.19;
+// SPDX-License-Identifier: Unlicense
+pragma solidity ^0.8.19;
 
 import {CadenceArchUtils} from "./CadenceArchUtils.sol";
 import {Xorshift128plus} from "./Xorshift128plus.sol";

--- a/solidity/src/CoinToss.sol
+++ b/solidity/src/CoinToss.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Unlicense
 pragma solidity 0.8.19;
 
 import {CadenceRandomConsumer} from "./CadenceRandomConsumer.sol";

--- a/solidity/src/Xorshift128plus.sol
+++ b/solidity/src/Xorshift128plus.sol
@@ -1,5 +1,5 @@
-// SPDX-License-Identifier: MIT
-pragma solidity 0.8.19;
+// SPDX-License-Identifier: Unlicense
+pragma solidity ^0.8.19;
 
 /**
  * @dev This library implements the Xorshift128+ pseudo-random number generator (PRG) algorithm.

--- a/solidity/src/test/TestCadenceRandomConsumer.sol
+++ b/solidity/src/test/TestCadenceRandomConsumer.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Unlicense
 pragma solidity 0.8.19;
 
 import {CadenceRandomConsumer} from "../CadenceRandomConsumer.sol";

--- a/solidity/test/CadenceRandomConsumer.t.sol
+++ b/solidity/test/CadenceRandomConsumer.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Unlicense
 pragma solidity 0.8.19;
 
 import "forge-std/Test.sol";

--- a/solidity/test/CoinToss.t.sol
+++ b/solidity/test/CoinToss.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Unlicense
 pragma solidity 0.8.19;
 
 import "forge-std/Test.sol";


### PR DESCRIPTION
### Description

- Updates SPDX License Identifiers across Solidity contracts
- Unlocks the Solidity compiler pragma for library, interface, and abstract contracts after finding difficulty using them in an unrelated repo