### PR TITLE
Remove RandomConsumer.Consumer initialization

### DIFF
--- a/scripts/random-consumer/can_fulfill_request.cdc
+++ b/scripts/random-consumer/can_fulfill_request.cdc
@@ -1,0 +1,16 @@
+import "RandomConsumer"
+
+/// Returns whether a particular Request can be fulfilled or not. If a Request is not found, `nil` is returned
+///
+/// @param requestAddress: The address where the Request is stored
+/// @param requestStoragePath: The StoragePath where the Request is stored in the requestAddress account
+///
+/// @return Whether the request can be fulfilled or not, `nil` if the Request is not found
+access(all)
+fun main(requestAddress: Address, requestStoragePath: StoragePath): Bool? {
+    if let request = getAuthAccount<auth(Storage) &Account>(requestAddress).storage
+        .borrow<&RandomConsumer.Request>(from: requestStoragePath) {
+        return request.canFullfill()
+    }
+    return nil
+}

--- a/scripts/random-consumer/get_request_block.cdc
+++ b/scripts/random-consumer/get_request_block.cdc
@@ -1,0 +1,16 @@
+import "RandomConsumer"
+
+/// Returns the block beyond which a given Request can be fulfilled
+///
+/// @param requestAddress: The address where the Request is stored
+/// @param requestStoragePath: The StoragePath where the Request is stored in the requestAddress account
+///
+/// @return The block beyond which a given Request can be fulfilled, `nil` if the Request is not found
+access(all)
+fun main(requestAddress: Address, requestStoragePath: StoragePath): Bool? {
+    if let request = getAuthAccount<auth(Storage) &Account>(requestAddress).storage
+        .borrow<&RandomConsumer.Request>(from: requestStoragePath) {
+        return request.canFullfill()
+    }
+    return nil
+}

--- a/scripts/random-consumer/get_request_info.cdc
+++ b/scripts/random-consumer/get_request_info.cdc
@@ -1,0 +1,29 @@
+import "RandomConsumer"
+
+/// Simple data struct representing Request state
+access(all) struct RandomRequestInfo {
+    /// The block height at which the request was made
+    access(all) let block: UInt64
+    /// Whether the request has been fulfilled
+    access(all) var fulfilled: Bool
+
+    init(_ blockHeight: UInt64, _ fulfilled: Bool) {
+        self.block = blockHeight
+        self.fulfilled = fulfilled
+    }
+}
+
+/// Returns the Request's block and whether it can be fulfilled. `nil` is returned if no Request was found
+///
+/// @param requestAddress: The address where the Request is stored
+/// @param requestStoragePath: The StoragePath where the Request is stored in the requestAddress account
+///
+/// @return A RandomRequestInfo struct containing the Request's state or `nil` if no Request was found
+access(all)
+fun main(requestAddress: Address, requestStoragePath: StoragePath): RandomRequestInfo? {
+    if let request = getAuthAccount<auth(Storage) &Account>(requestAddress).storage
+        .borrow<&RandomConsumer.Request>(from: requestStoragePath) {
+        return RandomRequestInfo(request.block, request.canFullfill())
+    }
+    return nil
+}

--- a/tests/coin_toss_tests.cdc
+++ b/tests/coin_toss_tests.cdc
@@ -27,8 +27,6 @@ fun setup() {
         arguments: []
     )
     Test.expect(err, Test.beNil())
-    let initRes = executeTransaction("../transactions/random-consumer/initialize_consumer.cdc", [], coinToss)
-    Test.expect(initRes, Test.beSucceeded())
 
     err = Test.deployContract(
         name: "CoinToss",

--- a/tests/random_consumer_tests.cdc
+++ b/tests/random_consumer_tests.cdc
@@ -21,9 +21,6 @@ fun setup() {
         arguments: []
     )
     Test.expect(err, Test.beNil())
-
-    let initRes = executeTransaction("../transactions/random-consumer/initialize_consumer.cdc", [], randomConsumer)
-    Test.expect(initRes, Test.beSucceeded())
 }
 
 access(all)


### PR DESCRIPTION
### Description

- Follow up to #33 removing the Consumer initialization method post-update
- Add scripts to get stored Request info